### PR TITLE
fix 0.1.12 issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aindev/connect-redis-sdk",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "AIN Connect SDK for Redis",
   "repository": {
     "type": "git",

--- a/src/__tests__/models/redis.test.ts
+++ b/src/__tests__/models/redis.test.ts
@@ -37,6 +37,11 @@ describe('redis test', () => {
     redisClient.set('onkey', 'onvalue');
   });
 
+  it('delete string key test', async () => {
+    const reply = await redisClient.del('strkey');
+    expect(reply).toEqual(1);
+  });
+
   // object
   it('set/get object test', async () => {
     const testObj = { key1: 'value1', key2: JSON.stringify({ aaa: 1, ccc: 'ddd' }) };
@@ -62,5 +67,11 @@ describe('redis test', () => {
       done();
     });
     redisClient.set('onobjkey', testObj);
+  });
+
+  it('delete object key test', async () => {
+    const reply = await redisClient.del('objkey');
+    // reply == number of deleted fields
+    expect(reply).toEqual(2);
   });
 });

--- a/src/common/error.ts
+++ b/src/common/error.ts
@@ -1,7 +1,7 @@
 export const enum STATUS_CODE {
-  success = 0,
-  invalidParams = 1,
-  unexpected = 500,
+  success = '0',
+  invalidParams = '1',
+  unexpected = '500',
 }
 
 export class ConnectError extends Error {
@@ -13,7 +13,7 @@ export class ConnectError extends Error {
 
   private errorMessage?: string
 
-  constructor(private statusCode: number) {
+  constructor(private statusCode: string) {
     super();
     this.name = 'CustomError';
     if (!ConnectError.MESSAGE[statusCode]) {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -5,7 +5,7 @@ export interface RedisCallback {
 export type EnvType = 'prod' | 'staging';
 
 export type PodPhaseList = 'Pending' | 'Running' | 'Succeeded' | 'Failed' | 'Unknown';
-export type StorageStatus = 'pending' | 'createStorage' | 'success' | 'failed' | 'on-migration';
+export type StorageStatus = 'Available' | 'Bound' | 'Released' | 'Failed';
 
 export type ConditionType = 'Initialized' | 'Ready' | 'ContainersReady' | 'PodScheduled';
 
@@ -74,6 +74,13 @@ export type StorageStatusParams = {
   }
 }
 
+/* Types for Client */
+export type RequestReturn<T> = {
+  statusCode: string;
+  result?: T;
+  errMessage?: string;
+}
+
 export type DeployParams = {
   clusterName?: string;
   namespaceId: string;
@@ -92,10 +99,11 @@ export type DeployParams = {
     imageName: string;
     nodePoolName?: string;
     storageSpec?: {
-      name: string;
-      mountPath: string;
-      subPath?: string;
-      isSecret?: boolean;
+      [storageId: string]: {
+        mountPath: string;
+        subPath?: string;
+        isSecret?: boolean;
+      }
     }
     hwSpec: {
       cpuPerCore: number;
@@ -112,20 +120,12 @@ export type DeployParams = {
   runningTimeout?: number;
 }
 
-/* Types for Client */
-export type RequestReturn<T> = {
-  statusCode: number;
-  result?: T;
-  errMessage?: string;
-}
-
 export type DeployReturn = {
   clusterName: string;
   containerId: string;
   endpoint: {
     [post: string]: string
   };
-  storageId?: string;
 }
 
 export type RedeployParams = {
@@ -178,6 +178,7 @@ export type DeleteStorageParams = {
 }
 
 export type CreateSecretParams = {
+  clusterName: string;
   namespaceId: string;
   name: string;
   type: string;

--- a/src/models/redis.ts
+++ b/src/models/redis.ts
@@ -146,19 +146,25 @@ export default class RedisClient {
         if (err) {
           reject(err);
         } else if (type === 'hash') {
-          this.client.hdel(key, (error, value) => {
-            if (error) {
-              reject(error);
+          this.client.hkeys(key, (errHkeys, fields) => {
+            if (errHkeys) {
+              reject(errHkeys);
             } else {
-              resolve(value);
+              this.client.hdel(key, ...fields, (error, reply) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(reply);
+                }
+              });
             }
           });
         } else { // type === 'string'
-          this.client.del(key, (error, value) => {
+          this.client.del(key, (error, reply) => {
             if (error) {
               reject(error);
             } else {
-              resolve(value);
+              resolve(reply);
             }
           });
         }


### PR DESCRIPTION
* deploymentParams쪽에서 storageSpec type은 array로 변경하기
* StorageStatus type = ‘Available’ | ‘Bound’ | ‘Released’ | ‘Failed’ 수정
* statusCode기 문자열로 redis에 적혀 client쪽에서  성공 여부 판단 로직에서 문자열과 숫자를 비교해서 항상 fail로 나옴
* CreateSecretParams에 clusterName추가
* redis delete 로직에서 에러 (handledPromiseRejectionWarning: ReplyError: ERR wrong number of arguments for ‘hdel’ command)
  * hash key에 대해서 모든 field를 한번에 날리는게 없어서, 모든 field값 가져와서 날려줄 수 있도록 변경